### PR TITLE
- 將原本 /api/analyze 的所有邏輯抽離到 AzureImageAnalyzer 實作 IImageAnalyzer

### DIFF
--- a/Dto/ImageAnalysisResult.cs
+++ b/Dto/ImageAnalysisResult.cs
@@ -1,0 +1,10 @@
+public class ImageAnalysisResult
+{
+    public IEnumerable<(string Name, double Confidence)> Tags { get; set; } = Enumerable.Empty<(string, double)>();
+    public IEnumerable<(string Name, double Confidence)> Objects { get; set; } = Enumerable.Empty<(string, double)>();
+    public string? Caption { get; set; }
+    public double? CaptionConfidence { get; set; }
+    public IEnumerable<string> OcrLines { get; set; } = Enumerable.Empty<string>();
+    public GptResult? GptDescription { get; set; }
+    public double RequestDurationMs { get; set; }
+}

--- a/Helpers/AzureImageAnalyzer.cs
+++ b/Helpers/AzureImageAnalyzer.cs
@@ -1,0 +1,121 @@
+using OpenAI.Chat; // 2.x SDK
+using Microsoft.Azure.CognitiveServices.Vision.ComputerVision;
+using Microsoft.Azure.CognitiveServices.Vision.ComputerVision.Models;
+using System.Diagnostics;
+using SixLabors.ImageSharp.Processing;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+
+public class AzureImageAnalyzer : IImageAnalyzer
+{
+    private readonly ComputerVisionClient _cv;
+    private readonly ChatClient _chatClient;
+
+    public AzureImageAnalyzer(ComputerVisionClient cv, ChatClient chatClient)
+    {
+        _cv = cv;
+        _chatClient = chatClient;
+    }
+
+    public async Task<ImageAnalysisResult> AnalyzeAsync(byte[] bytes)
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        // Computer Vision 分析
+        var features = new List<VisualFeatureTypes?>
+            { VisualFeatureTypes.Description, VisualFeatureTypes.Tags, VisualFeatureTypes.Objects };
+        using var ms1 = new MemoryStream(bytes);
+        var analysis = await _cv.AnalyzeImageInStreamAsync(ms1, features);
+
+        // OCR
+        var ocrLines = await ReadOcrAsync(bytes);
+
+        // GPT multimodal
+        var gptResult = await AnalyzeWithOpenAIAsync(analysis, ocrLines, bytes);
+
+        stopwatch.Stop();
+
+        return new ImageAnalysisResult
+        {
+            Tags = analysis.Tags?.Where(t => t.Confidence > 0.88).Select(t => (t.Name, t.Confidence)) ?? Enumerable.Empty<(string, double)>(),
+            Objects = analysis.Objects?.Select(o => (o.ObjectProperty, o.Confidence)) ?? Enumerable.Empty<(string, double)>(),
+            Caption = analysis.Description?.Captions?.OrderByDescending(c => c.Confidence).FirstOrDefault()?.Text,
+            CaptionConfidence = analysis.Description?.Captions?.OrderByDescending(c => c.Confidence).FirstOrDefault()?.Confidence,
+            OcrLines = ocrLines,
+            GptDescription = gptResult,
+            RequestDurationMs = stopwatch.ElapsedMilliseconds / 1000.0
+        };
+    }
+
+    private async Task<List<string>> ReadOcrAsync(byte[] bytes)
+    {
+        using var ms = new MemoryStream(bytes);
+        var readOp = await _cv.ReadInStreamAsync(ms);
+        var opId = readOp.OperationLocation.Split('/').Last();
+
+        ReadOperationResult readResult;
+        do
+        {
+            readResult = await _cv.GetReadResultAsync(Guid.Parse(opId));
+            await Task.Delay(500);
+        } while (readResult.Status == OperationStatusCodes.Running || readResult.Status == OperationStatusCodes.NotStarted);
+
+        var lines = new List<string>();
+        if (readResult.Status == OperationStatusCodes.Succeeded)
+        {
+            foreach (var page in readResult.AnalyzeResult.ReadResults)
+                foreach (var line in page.Lines)
+                    lines.Add(line.Text);
+        }
+
+        return lines;
+    }
+
+    private async Task<GptResult?> AnalyzeWithOpenAIAsync(ImageAnalysis analysis, List<string> ocrLines, byte[] bytes)
+    {
+        // ImageSharp 縮圖 + Base64
+        using var image = SixLabors.ImageSharp.Image.Load(bytes);
+        int maxSize = 256;
+        int width = image.Width > image.Height ? maxSize : image.Width * maxSize / image.Height;
+        int height = image.Height >= image.Width ? maxSize : image.Height * maxSize / image.Width;
+        image.Mutate(x => x.Resize(width, height));
+
+        using var msThumb = new MemoryStream();
+        var encoder = new SixLabors.ImageSharp.Formats.Jpeg.JpegEncoder { Quality = 70 };
+        image.Save(msThumb, encoder);
+        string base64Image = Convert.ToBase64String(msThumb.ToArray());
+        string imageDataUri = $"data:image/jpeg;base64,{base64Image}";
+
+        string caption = analysis.Description?.Captions?.OrderByDescending(c => c.Confidence).FirstOrDefault()?.Text;
+        var tags = analysis.Tags?.Where(t => t.Confidence > 0.88).Select(t => t.Name) ?? Enumerable.Empty<string>();
+
+        string prompt = $@"
+我有一張圖片，Azure Computer Vision 的分析結果如下：
+- Caption: {caption}
+- Tags: {string.Join(", ", tags)}
+- OCR: {string.Join(" | ", ocrLines)}
+
+請幫我給出更精準的描述，用中文描述：
+1. 如果能判斷品牌或型號（例如 Tesla Cybertruck），請直接指出。
+2. 如果是電動車，請加上 '電動車' 標籤。
+3. 回傳 JSON 格式：{{ ""description"": ..., ""extraTags"": [...] }}
+";
+
+        var chatMessages = new List<ChatMessage>()
+        {
+            new SystemChatMessage("你是一個影像辨識專家"),
+            new UserChatMessage(new List<ChatMessageContentPart>
+            {
+                ChatMessageContentPart.CreateTextPart(prompt),
+                ChatMessageContentPart.CreateImagePart(new Uri(imageDataUri))
+            })
+        };
+
+        var completion = await _chatClient.CompleteChatAsync(chatMessages);
+        string gptResult = completion.Value.Content[0].Text.Replace("```json", "").Replace("```", "").Trim();
+        var match = Regex.Match(gptResult, "{.*}", RegexOptions.Singleline);
+        if (match.Success) return JsonSerializer.Deserialize<GptResult>(match.Value);
+        return null;
+    }
+}

--- a/Interface/IImageAnalyzer.cs
+++ b/Interface/IImageAnalyzer.cs
@@ -1,0 +1,4 @@
+public interface IImageAnalyzer
+{
+    Task<ImageAnalysisResult> AnalyzeAsync(byte[] imageBytes);
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,14 +1,8 @@
-using Azure;
 using OpenAI.Chat; // 2.x SDK
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Azure.CognitiveServices.Vision.ComputerVision;
-using Microsoft.Azure.CognitiveServices.Vision.ComputerVision.Models;
 using Microsoft.AspNetCore.Mvc;
 using Azure.AI.OpenAI;
-using System.Diagnostics;
-using SixLabors.ImageSharp.Processing;
-using System.Text.Json;
-using System.Text.RegularExpressions;
 
 var builder = WebApplication.CreateBuilder(args);
 // ----------------- CORS -----------------
@@ -41,6 +35,7 @@ var chatClient = new AzureOpenAIClient(
     .GetChatClient(deployName);
 
 builder.Services.AddSingleton(chatClient);
+builder.Services.AddSingleton<IImageAnalyzer, AzureImageAnalyzer>();
 
 // ----------------- Swagger -----------------
 builder.Services.AddEndpointsApiExplorer();
@@ -51,180 +46,26 @@ app.UseSwagger();
 app.UseSwaggerUI();
 app.UseCors("frontend");
 
-// ----------------- Minimal API Endpoint (Computer Vision + Azure OpenAI 2.x) -----------------
-app.MapPost("/api/analyze", async (HttpContext context,
-    [FromServices] ComputerVisionClient cv,
-    [FromServices] ChatClient client) =>
+app.MapPost("/api/analyze", async (HttpRequest req, [FromServices] IImageAnalyzer analyzer) =>
 {
-    try
+    if (!req.HasFormContentType)
+        return Results.BadRequest(new { message = "請使用 multipart/form-data 上傳" });
+
+    var form = await req.ReadFormAsync();
+    var file = form.Files["file"];
+    if (file == null || file.Length == 0)
+        return Results.BadRequest(new { message = "請上傳圖片檔" });
+
+    byte[] bytes;
+    using (var ms = new MemoryStream())
     {
-        var req = context.Request;
-        if (!req.HasFormContentType)
-            return Results.BadRequest(new ErrorResponse
-            {
-                Code = "InvalidRequest",
-                Message = "請使用 multipart/form-data 上傳"
-            });
-
-        var form = await req.ReadFormAsync();
-        var file = form.Files["file"]; // Postman 裡的檔案欄位名稱
-
-        if (file == null || file.Length == 0)
-            return Results.BadRequest(new ErrorResponse
-            {
-                Code = "FileMissing",
-                Message = "請上傳圖片檔"
-            });
-
-        // 將檔案裝進記憶體，避免後面要重複讀兩次（Analyze + OCR）
-        byte[] bytes;
-        using (var ms = new MemoryStream())
-        {
-            await file.CopyToAsync(ms);
-            bytes = ms.ToArray();
-        }
-
-        var stopwatch = Stopwatch.StartNew();
-
-    // Parallelize: Image Analysis + OCR 同時發起
-    var features = new List<VisualFeatureTypes?>()
-        { VisualFeatureTypes.Description, VisualFeatureTypes.Tags, VisualFeatureTypes.Objects };
-
-    using var ms1 = new MemoryStream(bytes);
-    var analyzeTask = cv.AnalyzeImageInStreamAsync(ms1, features);
-
-    using var ms2 = new MemoryStream(bytes);
-    var readTask = cv.ReadInStreamAsync(ms2);
-
-    await Task.WhenAll(analyzeTask, readTask);
-
-    var analysis = analyzeTask.Result;
-
-    // OCR 輪詢
-    var readOp = readTask.Result;
-    var opId = readOp.OperationLocation.Split('/').Last();
-    ReadOperationResult readResult;
-    do
-    {
-        readResult = await cv.GetReadResultAsync(Guid.Parse(opId));
-        await Task.Delay(500);
-    } while (readResult.Status == OperationStatusCodes.Running ||
-             readResult.Status == OperationStatusCodes.NotStarted);
-
-    var ocrLines = new List<string>();
-    if (readResult.Status == OperationStatusCodes.Succeeded)
-    {
-        foreach (var page in readResult.AnalyzeResult.ReadResults)
-            foreach (var line in page.Lines)
-                ocrLines.Add(line.Text);
+        await file.CopyToAsync(ms);
+        bytes = ms.ToArray();
     }
 
-    // ----------------- 呼叫 Azure OpenAI 2.x -----------------
-    var tags = analysis.Tags?
-    .Where(t => t.Confidence > 0.88)  // 只取信心值大於 88%
-    .Select(t => t.Name)
-    ?? Enumerable.Empty<string>();
-    var caption = analysis.Description?.Captions?.OrderByDescending(c => c.Confidence).FirstOrDefault()?.Text;
-
-    // ---------------------- ImageSharp 縮圖 + Base64 Data URI ----------------------
-    using var image = SixLabors.ImageSharp.Image.Load(bytes); // 載入圖片
-    int maxSize = 256; // 縮小尺寸
-    int width = image.Width > image.Height ? maxSize : image.Width * maxSize / image.Height;
-    int height = image.Height >= image.Width ? maxSize : image.Height * maxSize / image.Width;
-
-    image.Mutate(x => x.Resize(width, height)); // 縮圖
-
-    using var msThumb = new MemoryStream();
-    var encoder = new SixLabors.ImageSharp.Formats.Jpeg.JpegEncoder
-    {
-        Quality = 70 // 降低 JPEG 質量，減少 payload (傳送的資料量)
-    };
-    image.Save(msThumb, encoder); // 輸出 JPEG
-    string base64Image = Convert.ToBase64String(msThumb.ToArray());
-    string imageDataUri = $"data:image/jpeg;base64,{base64Image}";
-
-    string prompt = $@"
-我有一張圖片，Azure Computer Vision 的分析結果如下：
-- Caption: {caption}
-- Tags: {string.Join(", ", tags)}
-- OCR: {string.Join(" | ", ocrLines)}
-
-        請幫我給出更精準的描述，用中文描述：
-        1. 如果能判斷品牌或型號（例如 Tesla Cybertruck），請直接指出。
-        2. 如果是電動車，請加上 '電動車' 標籤。
-3. 回傳 JSON 格式：{{ ""description"": ..., ""extraTags"": [...] }}
-";
-
-    // 用 multimodal message（文字 + 圖片）
-    var chatMessages = new List<ChatMessage>()
-    {
-        new SystemChatMessage("你是一個影像辨識專家"),
-        new UserChatMessage(new List<ChatMessageContentPart>
-        {
-            ChatMessageContentPart.CreateTextPart(prompt),
-            ChatMessageContentPart.CreateImagePart(new Uri(imageDataUri))
-        })
-    };
-
-    var completion = await client.CompleteChatAsync(chatMessages);
-
-    // 清理 GPT 回傳，去掉 ```json、``` 和多餘換行
-    string gptResult = completion.Value.Content[0].Text
-        .Replace("```json", "")
-        .Replace("```", "")
-        .Trim();
-
-    // 用 Regex 找出 { 開頭到 } 結尾的 JSON
-    var match = Regex.Match(gptResult, "{.*}", RegexOptions.Singleline);
-    GptResult? gptJson = null;
-    if (match.Success)
-    {
-        gptJson = JsonSerializer.Deserialize<GptResult>(match.Value);
-    }
-
-    stopwatch.Stop();
-        double elapsedSeconds = stopwatch.ElapsedMilliseconds / 1000.0;
-
-        return Results.Ok(new
-        {
-            tags = analysis.Tags?
-                .Where(t => t.Confidence > 0.88)
-                .Select(t => new { t.Name, t.Confidence }) ?? Enumerable.Empty<object>(),
-            objects = analysis.Objects?.Select(o => new { Name = o.ObjectProperty, o.Confidence }) ?? Enumerable.Empty<object>(),
-            caption = caption,
-            captionConfidence = analysis.Description?.Captions?.OrderByDescending(c => c.Confidence).FirstOrDefault()?.Confidence,
-            ocr = ocrLines,
-            gptDescription = gptJson,
-            requestDurationMs = elapsedSeconds
-        });
-    }
-    catch (ComputerVisionOcrErrorException ex)
-    {
-        return Results.BadRequest(new ErrorResponse
-        {
-            Code = MessageCodeEnum.OcrFailed.ToString(),
-            Message = $"{EnumHelper.GetEnumDescription(MessageCodeEnum.OcrFailed)}: {ex.Message}",
-
-        });
-    }
-    catch (SixLabors.ImageSharp.UnknownImageFormatException ex)
-    {
-        return Results.BadRequest(new ErrorResponse
-        {
-            Code = MessageCodeEnum.ImageFormatError.ToString(),
-            Message = $"{EnumHelper.GetEnumDescription(MessageCodeEnum.ImageFormatError)}: {ex.Message}"
-        });
-    }
-    catch (Exception ex)
-    {
-        return Results.Problem(new ErrorResponse
-        {
-            Code = MessageCodeEnum.非預期系統錯誤.ToString(),
-            Message = $"{EnumHelper.GetEnumDescription(MessageCodeEnum.ServerError)}: {ex.Message}"
-        }.ToString(), statusCode: 500);
-    }
-})
-.AllowAnonymous(); // <- 不需要 Anti-Forgery
+    var result = await analyzer.AnalyzeAsync(bytes);
+    return Results.Ok(result);
+});
 
 // ----------------- Minimal API Endpoint (Azure OpenAI 2.x Test) -----------------
 app.MapGet("/test-openai", async ([FromServices] ChatClient client) =>


### PR DESCRIPTION
- Minimal API 只負責讀取檔案與呼叫 IImageAnalyzer，降低 Program.cs 複雜度
- 減少 Endpoint 內部程式碼，方便未來測試、維護與替換 AI/Computer Vision 實作